### PR TITLE
More image fixes

### DIFF
--- a/00-sys-tweaks/01-run.sh
+++ b/00-sys-tweaks/01-run.sh
@@ -26,6 +26,7 @@ install -m 644 files/jamulus.ini					"${ROOTFS_DIR}/var/lib/jacktrip"
 install -m 755 files/jacktrip-init.sh		"${ROOTFS_DIR}/usr/local/bin"
 install -m 755 files/jacktrip-beacon.sh		"${ROOTFS_DIR}/usr/local/bin"
 install -m 755 files/jacktrip-patches.sh	"${ROOTFS_DIR}/usr/local/bin"
+install -m 755 files/jacktrip-credentials.sh	"${ROOTFS_DIR}/usr/local/bin"
 install -m 755 files/jacktrip-wait-online.sh	"${ROOTFS_DIR}/usr/local/bin"
 install -m 755 files/jacktrip-agent		"${ROOTFS_DIR}/usr/local/bin"
 install -m 755 files/jacktrip			"${ROOTFS_DIR}/usr/local/bin"
@@ -35,6 +36,7 @@ install -m 755 files/jack-peak-meter		"${ROOTFS_DIR}/usr/local/bin"
 install -m 755 files/Jamulus			"${ROOTFS_DIR}/usr/local/bin"
 
 install -m 644 files/jacktrip-patches.service	"${ROOTFS_DIR}/etc/systemd/system/"
+install -m 644 files/jacktrip-credentials.service	"${ROOTFS_DIR}/etc/systemd/system/"
 install -m 644 files/jacktrip-init.service	"${ROOTFS_DIR}/etc/systemd/system/"
 install -m 644 files/jacktrip-agent.service	"${ROOTFS_DIR}/etc/systemd/system/"
 install -m 644 files/jacktrip-clock.service	"${ROOTFS_DIR}/etc/systemd/system/"
@@ -78,6 +80,7 @@ useradd -r -M -N -G audio -s /usr/sbin/nologin jamulus
 systemctl daemon-reload
 
 systemctl enable jacktrip-patches
+systemctl enable jacktrip-credentials
 systemctl enable jacktrip-init
 systemctl enable jacktrip-agent
 systemctl enable jacktrip-clock

--- a/00-sys-tweaks/files/jacktrip-agent.service
+++ b/00-sys-tweaks/files/jacktrip-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=JackTrip-Agent
-After=network.target jacktrip-patches.service jacktrip-init.service
+After=network.target jacktrip-patches.service jacktrip-credentials.service jacktrip-init.service
 
 [Service]
 Type=simple

--- a/00-sys-tweaks/files/jacktrip-credentials.service
+++ b/00-sys-tweaks/files/jacktrip-credentials.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=JackTrip-Credentials
+Before=bthelper@hci0.service
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+ExecStart=/usr/local/bin/jacktrip-credentials.sh
+RemainAfterExit=true
+Restart=no
+StandardOutput=journal
+StandardError=inherit
+SyslogIdentifier=jacktrip-credentials
+
+[Install]
+WantedBy=jacktrip-agent.service

--- a/00-sys-tweaks/files/jacktrip-credentials.sh
+++ b/00-sys-tweaks/files/jacktrip-credentials.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# JackTrip Raspberry Pi Image: Credentials Service
+# Copyright (c) 2020-2021 JackTrip Labs, Inc.
+
+CONFIG_DIR=/etc/jacktrip
+CREDENTIALS_FILE="${CONFIG_DIR}/credentials"
+
+# get a random string (default 15). Optionally set a random length.
+# random_string        -> 15 chars
+# random_string 50     -> 50 chars
+# random_string 20 80  -> will be between 20 and 80 chars long
+# from https://www.supertechcrew.com/random-numbers-strings-bash-shell-scripting/#:~:text=Creating%20Random%20Numbers%20and%20Strings,--random-source=/dev/urandom%20-i%200-100%20-n%201
+random_string() {
+        local l=15
+        [ -n "$1" ] && l=$1
+        [ -n "$2" ] && l=$(shuf --random-source=/dev/urandom -i $1-$2 -n 1)
+        tr -dc A-Za-z0-9 < /dev/urandom | head -c ${l} | xargs
+}
+
+# Remount volumes read-write
+mount -o remount,rw /
+mount -o remount,rw /boot
+
+# update API credentials, if necessary
+if [ ! `grep "^[a-zA-Z0-9]*\.[a-zA-Z0-9]*$" ${CREDENTIALS_FILE}` ]; then
+	echo "Generating new credentials file: ${CREDENTIALS_FILE}"
+	API_PREFIX=`random_string 7`
+	API_SECRET=`random_string 32`
+	echo "${API_PREFIX}.${API_SECRET}" > ${CREDENTIALS_FILE}
+fi
+
+# Remount volumes read-only
+sync
+mount -o remount,ro /
+mount -o remount,ro /boot

--- a/00-sys-tweaks/files/jacktrip-init.service
+++ b/00-sys-tweaks/files/jacktrip-init.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=JackTrip-Init
 After=jacktrip-patches.service
-Before=rc-local.service
+Before=rc-local.service avahi-daemon.service
 
 [Service]
 Type=oneshot

--- a/00-sys-tweaks/files/jacktrip-init.sh
+++ b/00-sys-tweaks/files/jacktrip-init.sh
@@ -6,21 +6,8 @@
 CONFIG_DIR=/etc/jacktrip
 ETC_AVAHI_SERVICES_DIR=/etc/avahi/services
 TMP_AVAHI_SERVICES_DIR=/tmp/avahi/services
-CREDENTIALS_FILE="${CONFIG_DIR}/credentials"
 DEVICENAME_FILE="${CONFIG_DIR}/devicename"
 DEVICETYPE_FILE="${CONFIG_DIR}/devicetype"
-
-# get a random string (default 15). Optionally set a random length.
-# random_string        -> 15 chars
-# random_string 50     -> 50 chars
-# random_string 20 80  -> will be between 20 and 80 chars long
-# from https://www.supertechcrew.com/random-numbers-strings-bash-shell-scripting/#:~:text=Creating%20Random%20Numbers%20and%20Strings,--random-source=/dev/urandom%20-i%200-100%20-n%201
-random_string() {
-        local l=15
-        [ -n "$1" ] && l=$1
-        [ -n "$2" ] && l=$(shuf --random-source=/dev/urandom -i $1-$2 -n 1)
-        tr -dc A-Za-z0-9 < /dev/urandom | head -c ${l} | xargs
-}
 
 # ensure that a line exists in /boot/config.txt
 ini_ensure() {
@@ -68,22 +55,29 @@ function check_hat {
 	fi
 }
 
-# detect supported sound card
+# detect supported alsa sound card
 function detect_card {
+	# Assume that the first ALSA card is the one we want to use (if it exists)
+	DEVICETYPE=$(aplay -l 2> /dev/null | grep -m 1 'card [0-9]\+:' | sed 's/card [0-9]\+: \([^]]\+\) \[\([^]]\+\)\].*$/\2/')
+	DEVICENAME=$(aplay -l 2> /dev/null | grep -m 1 'card [0-9]\+:' | sed 's/card [0-9]\+: \([^]]\+\) \[\([^]]\+\)\].*$/\1/')
+}
+
+# detect supported sound card (prefer HAT)
+function detect_hat {
 	check_hat
 
 	# check if HiFiBerry DAC+ ADC Pro is already configured
 	verify_card "sndrpihifiberry" "snd_rpi_hifiberry_dacplusadcpro"
 	if [ "$DEVICETYPE" != "" ]; then
 		# Set headphone amp volume for Stage
-		i2cset -y 1 0x60 0x01 0xc0 2>/dev/null
-		i2cset -y 1 0x60 0x02 0x31 2>/dev/null
+		i2cset -y 1 0x60 0x01 0xc0 2>/dev/null || true
+		i2cset -y 1 0x60 0x02 0x31 2>/dev/null || true
 		return
 	fi
 
 	# Check i2cget for HiFiBerry DAC+ ADC Pro
 	if [ "$HATCARD" != "DAC+ ADC Pro" ]; then
-		res=`i2cget -y 1 0x4a 25 2>/dev/null`
+		res=`i2cget -y 1 0x4a 25 2>/dev/null || true`
 		if [ "$res" == "0x00" ]; then
 			HATCARD="DAC+ ADC Pro"
 		fi
@@ -110,12 +104,11 @@ function detect_card {
 		fi
 	fi
 
-	# Assume that the first ALSA card is the one we want to use (if it exists)
-	DEVICETYPE=$(aplay -l 2> /dev/null | grep -m 1 'card [0-9]\+:' | sed 's/card [0-9]\+: \([^]]\+\) \[\([^]]\+\)\].*$/\2/')
+	detect_card
 	if [ "$DEVICETYPE" != "" ]; then
-		DEVICENAME=$(aplay -l 2> /dev/null | grep -m 1 'card [0-9]\+:' | sed 's/card [0-9]\+: \([^]]\+\) \[\([^]]\+\)\].*$/\1/')
 		return
 	fi
+
 	if [ "$HATCARD" != "" ]; then
 		return -1
 	fi
@@ -147,11 +140,41 @@ function detect_card {
 	return -1
 }
 
+# turn off red and green lights
+function leds_off {
+	echo 0 > /sys/class/leds/led0/brightness
+	echo 0 > /sys/class/leds/led1/brightness
+}
+
+# turn on red and green lights
+function leds_on {
+	echo 1 > /sys/class/leds/led0/brightness
+	echo 1 > /sys/class/leds/led1/brightness
+}
+
+# turn on red and green lights
+function leds_flip {
+	STATUS=`cat /sys/class/leds/led0/brightness`
+	if [ "$STATUS" == "0" ]; then
+		leds_on
+	else
+		leds_off
+	fi
+}
+
 # update sound device
 function update_device {
 
 	# Detect sound card
-	detect_card
+	detect_hat
+
+	# Keep trying, so that a USB device can later be plugged in
+	while [ "$DEVICETYPE" == "" ]; do
+		echo "Unable to detect sound device"
+		leds_flip
+		sleep 5
+		detect_card
+	done
 
 	# Ensure config directory exists
 	if [ ! -d ${CONFIG_DIR} ]; then
@@ -169,12 +192,9 @@ function update_device {
 	fi
 
 	# Show results
-	if [ "$DEVICETYPE" == "" ]; then
-		echo "Unable to detect sound device"
-		return -1
-	fi
 	echo "Found sound device NAME=$DEVICENAME TYPE=$DEVICETYPE"
 	aplay -l
+	leds_on
 }
 
 # update /etc/issue
@@ -198,16 +218,6 @@ $APLAY
 EOF
 }
 
-# update API credentials, if necessary
-function update_credentials {
-	if [ ! `grep "^[a-zA-Z0-9]*\.[a-zA-Z0-9]*$" ${CREDENTIALS_FILE}` ]; then
-		echo "Generating new credentials file: ${CREDENTIALS_FILE}"
-		API_PREFIX=`random_string 7`
-		API_SECRET=`random_string 32`
-		echo "${API_PREFIX}.${API_SECRET}" > ${CREDENTIALS_FILE}
-	fi
-}
-
 # update avahi services directory
 function update_avahi_services {
 	# Ensure etc services directory exists
@@ -218,16 +228,16 @@ function update_avahi_services {
 	# Ensure tmp services directory exists
 	if [ ! -d ${TMP_AVAHI_SERVICES_DIR} ]; then
 		mkdir -p ${TMP_AVAHI_SERVICES_DIR}
+
+		# bind mount tmp services to etc services
+		mount --bind $TMP_AVAHI_SERVICES_DIR $ETC_AVAHI_SERVICES_DIR
+		#systemctl restart avahi-daemon
 	fi
 
 	# make sure ssh service file exists in tmp
 	if [ ! -f "${TMP_AVAHI_SERVICES_DIR}/ssh.service" ]; then
 		cp "/usr/share/doc/avahi-daemon/examples/ssh.service" "${TMP_AVAHI_SERVICES_DIR}/ssh.service"
 	fi
-
-	# bind mount tmp services to etc services
-	mount --bind $TMP_AVAHI_SERVICES_DIR $ETC_AVAHI_SERVICES_DIR
-	systemctl restart avahi-daemon
 }
 
 
@@ -237,7 +247,6 @@ mount -o remount,rw /boot
 
 # initialize config and services
 update_issue
-update_credentials
 update_avahi_services
 update_device
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ git clone https://github.com/RPi-Distro/pi-gen.git
 cd pi-gen && git clone git@github.com:jacktrip/jacktrip-image.git
 
 # Grab the latest binary files
-wget -q -O - https://files.jacktrip.org/binaries/jacktrip-image-files-20210812.tar.gz |tar -C jacktrip-image/00-sys-tweaks/files -xzvf -
+wget -q -O - https://files.jacktrip.org/binaries/jacktrip-image-files-20210916.tar.gz |tar -C jacktrip-image/00-sys-tweaks/files -xzvf -
 
 # Copy pi-gen config file
 cp jacktrip-image/config .


### PR DESCRIPTION
Extracted credentials generation out from jacktrip-init into a new
jacktrip-credentials service, which now runs before bthelper@hci0.
This ensures that credentials are generated before the BLE beacon
is activated.

Fixed an issue with avahi where it was creating new tmp bind mounts
every time jacktrip-init was restarted. Also eliminated a systemctl
restart command inside jacktrip-init.sh by making the avahi-daemon
service always run after jacktrip-init.

Updated audio interface detection in jacktrip-init so that if no
interface is detected, it will repeatedly retry every 5 seconds.
This allows one to plug in a USB interface after powering on the
device, and still have everything startup and work as expected.
When an interface is not detected, it will also now turn the green
and red LED lights on and off every 5 seconds to provide a visual
indication of the problem.

Note that earlier changes modified the light behavior so that red
solid on and green off means it is attempting to connect to the
Internet (if it stays that way for a long time, it indicates a
network failure). After an interface is successfully detected,
jacktrip-init will now turn green and red leds to solid on to
signal a successful startup of jacktrip-agent.