### PR TITLE
Reducing the amount of disk remounts at startup by instead making

### DIFF
--- a/00-sys-tweaks/files/jacktrip-agent.service
+++ b/00-sys-tweaks/files/jacktrip-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=JackTrip-Agent
-After=network.target jacktrip-patches.service jacktrip-credentials.service jacktrip-init.service
+After=jacktrip-init.service
 
 [Service]
 Type=simple

--- a/00-sys-tweaks/files/jacktrip-credentials.sh
+++ b/00-sys-tweaks/files/jacktrip-credentials.sh
@@ -18,10 +18,6 @@ random_string() {
         tr -dc A-Za-z0-9 < /dev/urandom | head -c ${l} | xargs
 }
 
-# Remount volumes read-write
-mount -o remount,rw /
-mount -o remount,rw /boot
-
 # update API credentials, if necessary
 if [ ! `grep "^[a-zA-Z0-9]*\.[a-zA-Z0-9]*$" ${CREDENTIALS_FILE}` ]; then
 	echo "Generating new credentials file: ${CREDENTIALS_FILE}"
@@ -29,8 +25,3 @@ if [ ! `grep "^[a-zA-Z0-9]*\.[a-zA-Z0-9]*$" ${CREDENTIALS_FILE}` ]; then
 	API_SECRET=`random_string 32`
 	echo "${API_PREFIX}.${API_SECRET}" > ${CREDENTIALS_FILE}
 fi
-
-# Remount volumes read-only
-sync
-mount -o remount,ro /
-mount -o remount,ro /boot

--- a/00-sys-tweaks/files/jacktrip-init.service
+++ b/00-sys-tweaks/files/jacktrip-init.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=JackTrip-Init
-After=jacktrip-patches.service
+After=jacktrip-patches.service jacktrip-credentials.service
 Before=rc-local.service avahi-daemon.service
 
 [Service]

--- a/00-sys-tweaks/files/jacktrip-patches.sh
+++ b/00-sys-tweaks/files/jacktrip-patches.sh
@@ -87,12 +87,5 @@ check_patches() {
     return 0
 }
 
-# Remount root read-write
-mount -o remount,rw /
-
 # main
 check_patches
-
-# Remount root read-only
-sync
-mount -o remount,ro /


### PR DESCRIPTION
jacktrip-init be the first service that does this, and ensuring that
jacktrip-patches and jacktrip-credentials always run before it.