### PR TITLE
Updates for RPI 4b rev 1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: RPi-Distro/pi-gen
+        ref: buster
         path: pi-gen
     - name: Checkout jacktrip-image
       uses: actions/checkout@v2

--- a/00-sys-tweaks/01-run.sh
+++ b/00-sys-tweaks/01-run.sh
@@ -91,7 +91,8 @@ systemctl enable ssh
 systemctl set-default multi-user.target
 
 # update kernel to 5.4.81 https://github.com/Hexxeh/rpi-firmware/commit/453e49bdd87325369b462b40e809d5f3187df21d
-PRUNE_MODULES=1 SKIP_WARNING=1 rpi-update 453e49bdd87325369b462b40e809d5f3187df21d
-rm -rf /boot.bak
+# no longer works with RPI 4b rev 1.5; using latest from buster branch instead
+#PRUNE_MODULES=1 SKIP_WARNING=1 rpi-update 453e49bdd87325369b462b40e809d5f3187df21d
+#rm -rf /boot.bak
 
 EOF

--- a/00-sys-tweaks/files/jacktrip-init.sh
+++ b/00-sys-tweaks/files/jacktrip-init.sh
@@ -202,6 +202,7 @@ function update_issue {
 	IP=$(hostname -I) || true
 	MAC=$(cat /sys/class/net/eth0/address) || true
 	APLAY=$(/usr/bin/aplay -l)
+	VERSION=$(cat /etc/jacktrip/patch)
 
 	if [ "$APLAY" == "" ]; then
 		APLAY="No sound card found"
@@ -210,6 +211,7 @@ function update_issue {
 	cat << EOF >/etc/issue
 Raspbian GNU/Linux 10 \\n \\l
 
+JackTrip Image $VERSION
 My IP address is $IP
 My MAC address is $MAC
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # JackTrip Raspberry Pi Image
 
 ```
-# Clone pi-gen repository
-git clone https://github.com/RPi-Distro/pi-gen.git
+# Clone buster branch of pi-gen repository
+git clone -b buster https://github.com/RPi-Distro/pi-gen.git
 
 # Clone this repository as a subdirectory
 cd pi-gen && git clone git@github.com:jacktrip/jacktrip-image.git
 
 # Grab the latest binary files
-wget -q -O - https://files.jacktrip.org/binaries/jacktrip-image-files-20211102.tar.gz |tar -C jacktrip-image/00-sys-tweaks/files -xzvf -
+wget -q -O - https://files.jacktrip.org/binaries/jacktrip-image-files-20220204.tar.gz |tar -C jacktrip-image/00-sys-tweaks/files -xzvf -
 
 # Copy pi-gen config file
 cp jacktrip-image/config .

--- a/pi-gen.patch
+++ b/pi-gen.patch
@@ -1,17 +1,17 @@
 diff --git a/build-docker.sh b/build-docker.sh
-index 5d31f86..2c9759e 100755
+index 01fd517..5bbad07 100755
 --- a/build-docker.sh
 +++ b/build-docker.sh
-@@ -106,6 +106,8 @@ else
- 		-v /dev:/dev \
+@@ -109,6 +109,8 @@ else
  		-v /lib/modules:/lib/modules \
+ 		${PIGEN_DOCKER_OPTS} \
  		--volume "${CONFIG_FILE}":/config:ro \
 +		--volume "${DIR}/work":/pi-gen/work \
 +		--volume "${DIR}/deploy":/pi-gen/deploy \
  		-e "GIT_HASH=${GIT_HASH}" \
  		pi-gen \
  		bash -e -o pipefail -c "dpkg-reconfigure qemu-user-static &&
-@@ -115,7 +117,7 @@ else
+@@ -118,7 +120,7 @@ else
  fi
  
  echo "copying results from deploy/"


### PR DESCRIPTION
Use buster pi-gen branch instead of main.

Use latest firmware from buster branch instead of fixed version.

Display image version via issue when device boots up.